### PR TITLE
Prevent repeated ICE finish

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1959,6 +1959,10 @@ module.exports = class RTCSession extends EventEmitter
 
           const ready = () =>
           {
+            if (finished) {
+              return;
+            }
+
             connection.removeEventListener('icecandidate', iceCandidateListener);
             connection.removeEventListener('icegatheringstatechange', iceGatheringStateListener);
 
@@ -1988,8 +1992,7 @@ module.exports = class RTCSession extends EventEmitter
                 ready
               });
             }
-
-            else if (!finished)
+            else
             {
               ready();
             }
@@ -1997,7 +2000,7 @@ module.exports = class RTCSession extends EventEmitter
 
           connection.addEventListener('icegatheringstatechange', iceGatheringStateListener = () =>
           {
-            if ((connection.iceGatheringState === 'complete') && !finished)
+            if (connection.iceGatheringState === 'complete')
             {
               ready();
             }


### PR DESCRIPTION
This is something I noticed while implementing a rudimentary ICE gathering timeout (see #432). As you can see [here](https://github.com/VIER-CognitiveVoice/reference-webrtc-client/blob/b96d1e43c92573e8e3775aa34c5eb5a9f464192a/src/client.ts#L247-L254), I defer the call to `IceCandidateEvent.ready` by a configurable timeout. If that timeout is elapses after the iceGatheringState changed to `completed`, then `ready` will be called twice.

All other calls to the ready function in `RTCSession.js` are already conditional on the `finished` variable, I simply pushed that condition into the function.